### PR TITLE
Update readme install command with git option

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ This is a command line interface (cli) for looking at files and their bytes.
 
 This tool requires [Rust](https://www.rust-lang.org/tools/install) to be installed.
 
-Since this crate isn't published yet, install it from the local path:
+Since this crate isn't published yet, install it from the git repo:
 
 ```
-cargo install --path .
+cargo install --git https://github.com/kyle-rader/FileOptics
 ```
 
 The tool will install globally and be accessible as `fo` on your command line.


### PR DESCRIPTION
Update README.md install command to use `cargo install --git` for direct installation from the repository.

---
<a href="https://cursor.com/background-agent?bcId=bc-1df81414-dd4d-4c80-9550-e8cdbcc3d609"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1df81414-dd4d-4c80-9550-e8cdbcc3d609"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

